### PR TITLE
fix for invalid preprocessing directive on OS X Maverick

### DIFF
--- a/src/Crypto/Skein/Internal.hsc
+++ b/src/Crypto/Skein/Internal.hsc
@@ -1,7 +1,6 @@
 {-# CFILES
       c_impl/reference/skein.c
-      c_impl/reference/skein_block.c
- #-}
+      c_impl/reference/skein_block.c #-}
 
 -----------------------------------------------------------------------------
 -- |


### PR DESCRIPTION
On OS X Maverick the compiler misunderstands 
# -}

at the end of a line as a malformed preprocessing directive. Putting it at the end of the previous line fixes that - or at least it builds.

```
dist/dist-sandbox-4c20042d/build/Crypto/Skein/Internal.hs:6:3:
     error: invalid preprocessing directive
     #-}
      ^
```

(fix for bug perceived on OS X Maverick, probably due to local command-line build tools,
Glasgow Haskell Compiler, Version 7.6.3, stage 2 booted by GHC version 7.4.2)
