### PR TITLE
Remove upper bounds on versions of cereal and crypto-api

### DIFF
--- a/skein.cabal
+++ b/skein.cabal
@@ -76,9 +76,9 @@ Library
     Build-depends:
         base         >= 3   && < 5,
         bytestring   >= 0.9,
-        cereal       >= 0.3 && < 0.5,
+        cereal       >= 0.3,
         tagged       >= 0.2 && < 0.8,
-        crypto-api   >= 0.6 && < 0.13
+        crypto-api   >= 0.6
 
     Build-tools: hsc2hs
     GHC-options: -Wall


### PR DESCRIPTION
The upper bounds for cereal and crypto-api do exclude the most recent versions of these packages. After removing the bounds the package still builds and works for me. I haven't done any specific tests. I guess that serialization with the new version of cereal is backward compatible but I haven't checked.
